### PR TITLE
Additional `makepeds` reporting and exclusion of reporter data stream

### DIFF
--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -62,6 +62,20 @@ check_running_jobs()
     REMJOBIDS=()
     for JOBID in "${JOBIDS[@]}"; do
         if  squeue | grep -q "$JOBID"; then
+            JOBSTATUS=`squeue | grep "${JOBID}" | awk '{print $5}'`
+            if [[ $JOBSTATUS == "R" ]]; then
+                echo "${JOBID} is RUNNING"
+            elif [[ "${JOBSTATUS}" == "PD" ]]; then
+                echo "${JOBID} is PENDING"
+            elif [[ "${JOBSTATUS}" == "CG" ]]; then
+                echo "${JOBID} is COMPLETING"
+            elif [[ "${JOBSTATUS}" == "PR" ]]; then
+                echo "${JOBID} has been PREEMPTED!"
+            elif [[ "${JOBSTATUS}" == "F" ]]; then
+                echo "${JOBID} has FAILED!"
+            else
+                echo "${JOBID} is STOPPED or SUSPENDED"
+            fi
             REMJOBIDS+=( "$JOBID" )
             NJOBS=$((NJOBS+1))
         fi
@@ -1037,7 +1051,7 @@ for MYDET in $DETS; do
 
     echo "-------------------- START CALIBRUN at $(date +'%T') for detector $MYDET----------------------------"
     source $SIT_ENV_DIR/manage/bin/psconda.sh
-    cmd="calibrun -r $RUN  -d $MYDET -P -e $EXP -x :dir=$XTCDIR $LOCARG"
+    cmd="calibrun -r $RUN  -d $MYDET -P -e $EXP -x :dir=$XTCDIR:stream=0-79 $LOCARG"
     echo "$cmd"
     $cmd
     echo "-------------------- END CALIBRUN at $(date +'%T') for detector $MYDET----------------------------"

--- a/scripts/makepeds_psana
+++ b/scripts/makepeds_psana
@@ -58,23 +58,23 @@ EOF
 
 check_running_jobs()
 {
+    declare -A SLURM_STAT_MSG = ( ["R"]="is RUNNING."
+                                  ["PD"]="is PENDING."
+                                  ["CG"]="is COMPLETING."
+                                  ["CD"]="has COMPLETED."
+                                  ["PR"]="was PREEMPTED!"
+                                  ["F"]="has FAILED!"
+                                  ["S"]="was SUSPENDED!"
+                                  ["ST"]="was STOPPED!" )
     NJOBS=0
     REMJOBIDS=()
     for JOBID in "${JOBIDS[@]}"; do
         if  squeue | grep -q "$JOBID"; then
-            JOBSTATUS=`squeue | grep "${JOBID}" | awk '{print $5}'`
-            if [[ $JOBSTATUS == "R" ]]; then
-                echo "${JOBID} is RUNNING"
-            elif [[ "${JOBSTATUS}" == "PD" ]]; then
-                echo "${JOBID} is PENDING"
-            elif [[ "${JOBSTATUS}" == "CG" ]]; then
-                echo "${JOBID} is COMPLETING"
-            elif [[ "${JOBSTATUS}" == "PR" ]]; then
-                echo "${JOBID} has been PREEMPTED!"
-            elif [[ "${JOBSTATUS}" == "F" ]]; then
-                echo "${JOBID} has FAILED!"
+            JOBSTATUS=$(squeue | grep "${JOBID}" | awk '{print $5}')
+            if [ "${SLURM_STAT_MSG[$JOBSTATUS]}" ]; then
+                echo "${JOBID} ${SLURM_STAT_MSG[$JOBSTATUS]}"
             else
-                echo "${JOBID} is STOPPED or SUSPENDED"
+                echo "${JOBID} has unknown status ${JOBSTATUS}!"
             fi
             REMJOBIDS+=( "$JOBID" )
             NJOBS=$((NJOBS+1))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Currently, `makepeds` waits until jobs complete, checking every 10 seconds, but does not indicate the job status (pending/running/etc). This PR provides feedback on the status of those submitted jobs so a decision can be made as to whether it's just a matter of waiting patiently or requesting additional resources (etc.).
- Currently, most portions of `makepeds` exclude the recorder datastream; however, the `calibrun` portion does not. This PR excludes the recorder data stream from this latter part as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Provides additional information to make decisions about compute resources. Resolves [[ECS-3879]](https://jira.slac.stanford.edu/browse/ECS-3879?filter=-1)
- Helps to improve the efficiency of `makepeds` by only considering events with usable detector information. Resolves [[ECS-3770]](https://jira.slac.stanford.edu/browse/ECS-3770)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested on experiment [insert experiment name here] run [insert run number here].

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- NA
<!--
## Screenshots (if appropriate):
-->
[Insert screenshot here]